### PR TITLE
fixing CI/CD for archive_data.json file during build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: archive-data
-          path: data/archive_data.json
+          path: data/
 
   prod:
     name: Deploy to prod
@@ -65,7 +65,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: archive-data
-          path: data/archive_data.json
+          path: data/
 
       - name: Deploy to Github Pages
         run: bash .github/repo_ci-cd/deployment/deploy.sh


### PR DESCRIPTION
Hey @kshull1,

I swear everything was working whenever I stopped messing around with the automation, but for some reason it isn't loading the images on the archive page :disappointed: 

![image](https://user-images.githubusercontent.com/10230166/167592452-7cda40da-eb00-4127-b9b7-8442f990c031.png)



So, I think it should be fixed with you merging this PR, you can see the preview here: 
https://elreydetoda.github.io/crs-website/archive/borders-in-us-mexico/

So, after you merge this PR you'll have to manually trigger a rebuild of the website (because of how I configured the automation). You should be able to go to this page: https://github.com/Climate-Refugee-Stories/crs-website/actions/workflows/cd.yml

Then there should be a dropdown like this to start the workflow:
![image](https://user-images.githubusercontent.com/10230166/167593470-f430f751-c823-4e1e-9cf2-a97fe85518f8.png)

