### PR TITLE
removing uncessary hugo arg for deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,7 +71,7 @@ jobs:
         run: bash .github/repo_ci-cd/deployment/deploy.sh
         env:
           GITHUBTOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ARGZ: --gc --minify --cleanDestinationDir -e prod
+          ARGZ: --gc --minify --cleanDestinationDir
           GH_PAGES: gh-pages
           #DEBUG: 'true'
 


### PR DESCRIPTION
Hey @kshull1 :wave: , 

Just recently found out that this argument should be unnecessary for how things are deploying, and it's normally better to remove unnecessary things in case they change in the future. So I figured I'd just do a quick PR to remove it :slightly_smiling_face: 

if it's merged I'll go ahead and check the GitHub action to make sure it was deployed properly, and if it doesn't I'll message here again so I can tell you what you can do to revert it :upside_down_face:
If the deployment fails it won't affect your currently deployed site, so no worries about breaking anything with the current website :grin: 

Hope you're doing well and have a great day! :grin: 