### PR TITLE
features/achive/page-title-update

### DIFF
--- a/layouts/partials/page-title.html
+++ b/layouts/partials/page-title.html
@@ -9,3 +9,13 @@
   </div>
 </section>
 <!-- /Page Title -->
+
+<--Page Banner-->
+  {{ with .Params.banner }}
+<header class="hero-area" style="background-image: url('https://photos.smugmug.com/photos/{{ .background_img }}/0/O/{{ .background_img }}-O.png');">
+  <div class="container text-center text-white">
+    <h1>{{ .title }}</h1>
+  </div>
+</header>
+{{ end }}
+<!-- /Page Banner -->


### PR DESCRIPTION
This section defines the content and appearance of the archive hero banner. You can customize the title text that appears over the image and specify the background_img using the SmugMug filename (e.g., i-ptQrJ35). The image must exist at https://photos.smugmug.com/photos/{filename}/0/X3/{filename}-X3.jpg. This front matter is used by the layout and must match formatting exactly. Do not include the full URL—only the SmugMug image ID string. You may update this content to reflect new campaigns, themes, or visuals for the site.